### PR TITLE
discover: promote nexus--babel-alexandria to ranked value tier

### DIFF
--- a/DISCOVERY.md
+++ b/DISCOVERY.md
@@ -1,0 +1,20 @@
+# Value Discovery: organvm/nexus--babel-alexandria
+
+**Discovered:** 2026-06-22 | **Status:** PROMOTED to ranked tier
+
+## Value Thesis
+
+Nexus Babel Alexandria contains a working, dependency-light FastAPI service (~4,700 lines of production Python, 28 REST endpoints, 2,700 lines of tests) that implements a genuinely rare capability: **deterministic 5-level text atomization with branching evolution and seeded-RNG replay**. Documents are decomposed into glyph-seeds (characters carrying phoneme, historic-form, thematic-tag metadata), syllables, words, sentences, and paragraphs — each level independently queryable and remixable. On top of that foundation sits a branch-timeline system (natural drift, synthetic mutation, phase shift, glyph fusion, remix across documents) where identical inputs deterministically produce identical outputs, making the entire transformation tree replayable and diffable. The plugin architecture already contains ML stubs (`ml_first` → `deterministic` fallback chain) ready to receive real providers, and the 50K-word RLOS specification in `docs/corpus/` is a substantive cross-disciplinary synthesis (category theory × Peircean semiotics × Aristotelian rhetoric × computational linguistics) that maps intellectual territory the NLP community has largely left unexplored. The most direct near-term value is as reusable estate infrastructure: any ORGAN-II (Poiesis) generative system, creative writing tool, or text-transformation pipeline in the organvm estate can consume the atomization + evolution REST API without GPU or ML dependencies. The single best concrete first task is **wiring the existing `PluginRegistry` ML stub slot to a Claude API provider** for the 9-layer analysis engine — this converts the heuristic-only MVP into an AI-backed analytical surface with minimal code changes (the plugin interface is already defined), proving the design's viability and creating a production-grade literary intelligence API.
+
+## Key Assets
+
+- **Atomization engine** (`src/nexus_babel/services/text_utils.py`, `glyph_data.py`): glyph-seed decomposition with phoneme/historic/thematic metadata; no ML required
+- **Branch evolution + replay** (`services/evolution.py`, `evolution_events.py`, `evolution_replay.py`): deterministic, seeded, diffable text-transformation timelines
+- **Remix engine** (`services/remix.py`, `remix_strategies.py`): interleave, thematic_blend, temporal_layer, glyph_collide across document pairs
+- **Plugin architecture** (`services/plugins.py`): ML stub slots ready for real providers (Claude, HuggingFace, etc.)
+- **28-endpoint REST API** with role-based auth, async job queue, hypergraph dual-write, governance dual-mode
+- **RLOS specification corpus** (`docs/corpus/`): 50K-word synthesis of SHRG, DisCoCat, Peircean semiotics, Aristotelian rhetoric
+
+## First Task
+
+Wire a Claude API provider into `PluginRegistry` (`src/nexus_babel/services/plugins.py`) to back the 9-layer linguistic analysis engine, replacing the `ml_stub` provider with real inference and demonstrating the plugin fallback chain end-to-end.

--- a/value-repos.json
+++ b/value-repos.json
@@ -1,0 +1,3 @@
+[
+  "organvm/nexus--babel-alexandria"
+]


### PR DESCRIPTION
## Summary

- Adds `DISCOVERY.md` with a one-paragraph value thesis for `organvm/nexus--babel-alexandria`
- Creates `value-repos.json` and appends `organvm/nexus--babel-alexandria` to promote it into the ranked tier
- Auto-discovery run: 2026-06-22

## Value Thesis (excerpt)

This repo contains a working, dependency-light FastAPI service (~4,700 lines, 28 REST endpoints) implementing a genuinely rare capability: **deterministic 5-level text atomization with branching evolution and seeded-RNG replay**. The plugin architecture has ML stubs ready for real providers; the single best first task is wiring the existing `PluginRegistry` ML stub to a Claude API provider for the 9-layer analysis engine.

## First Task

Wire a Claude API provider into `PluginRegistry` (`src/nexus_babel/services/plugins.py`) to back the 9-layer linguistic analysis engine.

## Test plan

- [x] `DISCOVERY.md` present with complete value thesis
- [x] `value-repos.json` created and contains `organvm/nexus--babel-alexandria`
- [x] No existing tests broken (no code changes, only new files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)