### PR TITLE
[limen HEAL-cifix-organvm-nexus--babel-alexandria-125] fix failing CI on organvm/nexus--babel-alexandria#125

### DIFF
--- a/DISCOVERY.md
+++ b/DISCOVERY.md
@@ -1,0 +1,20 @@
+# Value Discovery: organvm/nexus--babel-alexandria
+
+**Discovered:** 2026-06-22 | **Status:** PROMOTED to ranked tier
+
+## Value Thesis
+
+Nexus Babel Alexandria contains a working, dependency-light FastAPI service (~4,700 lines of production Python, 28 REST endpoints, 2,700 lines of tests) that implements a genuinely rare capability: **deterministic 5-level text atomization with branching evolution and seeded-RNG replay**. Documents are decomposed into glyph-seeds (characters carrying phoneme, historic-form, thematic-tag metadata), syllables, words, sentences, and paragraphs — each level independently queryable and remixable. On top of that foundation sits a branch-timeline system (natural drift, synthetic mutation, phase shift, glyph fusion, remix across documents) where identical inputs deterministically produce identical outputs, making the entire transformation tree replayable and diffable. The plugin architecture already contains ML stubs (`ml_first` → `deterministic` fallback chain) ready to receive real providers, and the 50K-word RLOS specification in `docs/corpus/` is a substantive cross-disciplinary synthesis (category theory × Peircean semiotics × Aristotelian rhetoric × computational linguistics) that maps intellectual territory the NLP community has largely left unexplored. The most direct near-term value is as reusable estate infrastructure: any ORGAN-II (Poiesis) generative system, creative writing tool, or text-transformation pipeline in the organvm estate can consume the atomization + evolution REST API without GPU or ML dependencies. The single best concrete first task is **wiring the existing `PluginRegistry` ML stub slot to a Claude API provider** for the 9-layer analysis engine — this converts the heuristic-only MVP into an AI-backed analytical surface with minimal code changes (the plugin interface is already defined), proving the design's viability and creating a production-grade literary intelligence API.
+
+## Key Assets
+
+- **Atomization engine** (`src/nexus_babel/services/text_utils.py`, `glyph_data.py`): glyph-seed decomposition with phoneme/historic/thematic metadata; no ML required
+- **Branch evolution + replay** (`services/evolution.py`, `evolution_events.py`, `evolution_replay.py`): deterministic, seeded, diffable text-transformation timelines
+- **Remix engine** (`services/remix.py`, `remix_strategies.py`): interleave, thematic_blend, temporal_layer, glyph_collide across document pairs
+- **Plugin architecture** (`services/plugins.py`): ML stub slots ready for real providers (Claude, HuggingFace, etc.)
+- **28-endpoint REST API** with role-based auth, async job queue, hypergraph dual-write, governance dual-mode
+- **RLOS specification corpus** (`docs/corpus/`): 50K-word synthesis of SHRG, DisCoCat, Peircean semiotics, Aristotelian rhetoric, computational linguistics
+
+## First Task
+
+Wire a Claude API provider into `PluginRegistry` (`src/nexus_babel/services/plugins.py`) to back the 9-layer linguistic analysis engine, replacing the `ml_stub` provider with real inference and demonstrating the plugin fallback chain end-to-end.

--- a/docs/certainty/feature_usecase_ledger.json
+++ b/docs/certainty/feature_usecase_ledger.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-02-25T17:34:13.794679+00:00",
-  "root": "/Users/4jp/Workspace/organvm-i-theoria/nexus--babel-alexandria-",
+  "generated_at": "2026-07-06T21:14:57.137908+00:00",
+  "root": "/Users/4jp/Workspace/.limen-worktrees/heal-cifix-organvm-nexus--babel-alexandria-125-306fcd79",
   "summary": {
-    "files_total": 167,
+    "files_total": 176,
     "files_by_kind": {
-      "text": 165,
+      "text": 174,
       "pdf": 2
     },
     "features_total": 95,

--- a/docs/certainty/file_manifest.json
+++ b/docs/certainty/file_manifest.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-02-25T17:34:13.794679+00:00",
-  "root": "/Users/4jp/Workspace/organvm-i-theoria/nexus--babel-alexandria-",
+  "generated_at": "2026-07-06T21:14:57.137908+00:00",
+  "root": "/Users/4jp/Workspace/.limen-worktrees/heal-cifix-organvm-nexus--babel-alexandria-125-306fcd79",
   "summary": {
-    "files_total": 167,
+    "files_total": 176,
     "files_by_kind": {
-      "text": 165,
+      "text": 174,
       "pdf": 2
     },
     "features_total": 95,
@@ -21,11 +21,31 @@
   },
   "files": [
     {
+      "path": ".editorconfig",
+      "sha256": "f43d02afb32b2338f89ed3410b204fe01a3cf937577523869839fcf9d35abe9b",
+      "size_bytes": 443,
+      "kind": "text",
+      "lines": 35,
+      "pdf_pages": null,
+      "pdf_text_chars": null,
+      "conflict_markers": false
+    },
+    {
       "path": ".env.example",
       "sha256": "bd513bc016ad4f743b8da76509955de642431e582008bcbbf253d84f337a2e4a",
       "size_bytes": 1275,
       "kind": "text",
       "lines": 28,
+      "pdf_pages": null,
+      "pdf_text_chars": null,
+      "conflict_markers": false
+    },
+    {
+      "path": ".gitattributes",
+      "sha256": "d4b76be8eef7e4628d33476a18307efcd659da76115ade6c7718343349b564fa",
+      "size_bytes": 1091,
+      "kind": "text",
+      "lines": 72,
       "pdf_pages": null,
       "pdf_text_chars": null,
       "conflict_markers": false
@@ -71,8 +91,18 @@
       "conflict_markers": false
     },
     {
+      "path": ".github/dependabot.yml",
+      "sha256": "f197c830d9c106be64297e552e47995d321463424ccc764361d1d7e85842ed94",
+      "size_bytes": 404,
+      "kind": "text",
+      "lines": 21,
+      "pdf_pages": null,
+      "pdf_text_chars": null,
+      "conflict_markers": false
+    },
+    {
       "path": ".github/workflows/ci-minimal.yml",
-      "sha256": "7b2815104492c963854e9360561dc87db07baa3347c5b1c4c17871f237fc8413",
+      "sha256": "91e389d7239d56171e8652c5d4e9f480f1073398a4bed2c4e482be046228ddc1",
       "size_bytes": 1836,
       "kind": "text",
       "lines": 48,
@@ -92,30 +122,40 @@
     },
     {
       "path": "AGENTS.md",
-      "sha256": "e1a4e2d026f7402b861674bb5615f9a56f9f14b7d3f3c781851cffe304a71756",
-      "size_bytes": 763,
+      "sha256": "b5ddb1fd4175306209c9a5dd2ceb0b69333c71c744f20fa72f67064ccb119247",
+      "size_bytes": 496,
       "kind": "text",
-      "lines": 22,
+      "lines": 21,
       "pdf_pages": null,
       "pdf_text_chars": null,
       "conflict_markers": false
     },
     {
       "path": "CLAUDE.md",
-      "sha256": "9bc0059fbd3f785861229e05778a1e9b5bead10d039b11bf414135c015e81809",
-      "size_bytes": 14282,
+      "sha256": "643b6edf069642b8df8b3bfe4402b11fceea186480ba9737f23f121f2150b322",
+      "size_bytes": 25224,
       "kind": "text",
-      "lines": 206,
+      "lines": 418,
+      "pdf_pages": null,
+      "pdf_text_chars": null,
+      "conflict_markers": false
+    },
+    {
+      "path": "DISCOVERY.md",
+      "sha256": "30c511c5d11779483a56c5116be2c0c0fb8326df773e4e553a25d5d8d15b8aac",
+      "size_bytes": 3111,
+      "kind": "text",
+      "lines": 21,
       "pdf_pages": null,
       "pdf_text_chars": null,
       "conflict_markers": false
     },
     {
       "path": "GEMINI.md",
-      "sha256": "06f4ee20523b516b296c427463c6ad891e9f242f3bc8693b18fdbee13011f0ac",
-      "size_bytes": 957,
+      "sha256": "1afdc5a54732d02bddd774ef5b1bf3ada371f00bc239b98b8c37aa2d554b8314",
+      "size_bytes": 11908,
       "kind": "text",
-      "lines": 19,
+      "lines": 231,
       "pdf_pages": null,
       "pdf_text_chars": null,
       "conflict_markers": false
@@ -152,10 +192,10 @@
     },
     {
       "path": "README.md",
-      "sha256": "4e55cef95ef16aad3d659b91c65fc5f194cb74fcffe8932d99add216309362a2",
-      "size_bytes": 41701,
+      "sha256": "ba1955a853ad09a3f923c533abd85c855799615865b96471f6572a1ab4bd66cd",
+      "size_bytes": 42055,
       "kind": "text",
-      "lines": 441,
+      "lines": 449,
       "pdf_pages": null,
       "pdf_text_chars": null,
       "conflict_markers": false
@@ -571,9 +611,49 @@
       "conflict_markers": false
     },
     {
+      "path": "ecosystem.yaml",
+      "sha256": "ba1dc959b4cd5c61660899f46700eb91051d84bb9e2cc2be10c9442054c0ed35",
+      "size_bytes": 536,
+      "kind": "text",
+      "lines": 19,
+      "pdf_pages": null,
+      "pdf_text_chars": null,
+      "conflict_markers": false
+    },
+    {
+      "path": "ecosystem/pillar-dna/content.yaml",
+      "sha256": "846552206789f78c0291bafd3fc752226d788108eef138abf7ce0b0f962b8bce",
+      "size_bytes": 810,
+      "kind": "text",
+      "lines": 39,
+      "pdf_pages": null,
+      "pdf_text_chars": null,
+      "conflict_markers": false
+    },
+    {
+      "path": "ecosystem/pillar-dna/delivery.yaml",
+      "sha256": "dbb0b6248c4a99da07d6527074969effad35b9fd3237aaf18a6ea37a0530e5e0",
+      "size_bytes": 928,
+      "kind": "text",
+      "lines": 41,
+      "pdf_pages": null,
+      "pdf_text_chars": null,
+      "conflict_markers": false
+    },
+    {
+      "path": "network-map.yaml",
+      "sha256": "e458bca6737a298b73ad5ab19e2fa23108f24fdf710159ddebd7a76c6cccc886",
+      "size_bytes": 1916,
+      "kind": "text",
+      "lines": 90,
+      "pdf_pages": null,
+      "pdf_text_chars": null,
+      "conflict_markers": false
+    },
+    {
       "path": "pyproject.toml",
-      "sha256": "ac49fcafb9ed7d3cdddf58be1a1351e30197972670161fd32d920186522a2e14",
-      "size_bytes": 1012,
+      "sha256": "64baa66bc9f2e6f638c32b5e2f6c38053ff8d75b84c6f90a8ce2e1fc3b7117c4",
+      "size_bytes": 1015,
       "kind": "text",
       "lines": 52,
       "pdf_pages": null,
@@ -682,10 +762,10 @@
     },
     {
       "path": "seed.yaml",
-      "sha256": "2937e7625e3495a0233aa3e29b91dd3d27a65c8ef3029b7254a4da1115d13f92",
-      "size_bytes": 1094,
+      "sha256": "3d7e13674166b3f8032fe02597afb25396a840127f0fb0c7896aa0200df228ca",
+      "size_bytes": 1551,
       "kind": "text",
-      "lines": 42,
+      "lines": 50,
       "pdf_pages": null,
       "pdf_text_chars": null,
       "conflict_markers": false
@@ -1682,10 +1762,20 @@
     },
     {
       "path": "uv.lock",
-      "sha256": "ffee93fe4c0c746356a4f199c2e7705e2408d147245888289ec3b0f50928bc39",
+      "sha256": "1b1094b651712b936a78314fda34826cf548ce2c5e9efb8136acdbe3afd8dcc6",
       "size_bytes": 332744,
       "kind": "text",
       "lines": 1541,
+      "pdf_pages": null,
+      "pdf_text_chars": null,
+      "conflict_markers": false
+    },
+    {
+      "path": "value-repos.json",
+      "sha256": "78a795874f3234a06ded5ab1ebf32984b446feb260f812ff17aa70e9ba010204",
+      "size_bytes": 40,
+      "kind": "text",
+      "lines": 4,
       "pdf_pages": null,
       "pdf_text_chars": null,
       "conflict_markers": false

--- a/docs/certainty/repo_certainty_report.md
+++ b/docs/certainty/repo_certainty_report.md
@@ -1,7 +1,7 @@
 # Repository Certainty Report
 
-- Generated: `2026-02-25T17:34:13.794679+00:00`
-- Files processed: `167`
+- Generated: `2026-07-06T21:14:57.137908+00:00`
+- Files processed: `176`
 - Feature/use-case entries: `95`
 - Feature status split: `{'implemented': 10, 'planned': 85}`
 
@@ -27,20 +27,24 @@
 
 | Path | Kind | Bytes | Lines | SHA256 |
 |---|---|---:|---:|---|
+| `.editorconfig` | `text` | 443 | 35 | `f43d02afb32b2338f89ed3410b204fe01a3cf937577523869839fcf9d35abe9b` |
 | `.env.example` | `text` | 1275 | 28 | `bd513bc016ad4f743b8da76509955de642431e582008bcbbf253d84f337a2e4a` |
+| `.gitattributes` | `text` | 1091 | 72 | `d4b76be8eef7e4628d33476a18307efcd659da76115ade6c7718343349b564fa` |
 | `.github/AGENTS.md` | `text` | 834 | 24 | `1de9ad6c131630c992313eeb6fb5eaba74846cfa2f1588d3931b6d73c3875c13` |
 | `.github/GEMINI.md` | `text` | 957 | 19 | `c5b13e45745ce4c076bf2f0e9513f46c2b98fed22f08fd03e6ae52f106f95fb8` |
 | `.github/SECURITY.md` | `text` | 659 | 25 | `caa97e5ccbd5a6df132e0e746ee26c3466d3a8846c3f1821d0282a069d482ad0` |
 | `.github/SUPPORT.md` | `text` | 527 | 14 | `f50510518415c2dd8542c6f5df3a6733569fcef57248b76559e81fea74959a8f` |
-| `.github/workflows/ci-minimal.yml` | `text` | 1836 | 48 | `7b2815104492c963854e9360561dc87db07baa3347c5b1c4c17871f237fc8413` |
+| `.github/dependabot.yml` | `text` | 404 | 21 | `f197c830d9c106be64297e552e47995d321463424ccc764361d1d7e85842ed94` |
+| `.github/workflows/ci-minimal.yml` | `text` | 1836 | 48 | `91e389d7239d56171e8652c5d4e9f480f1073398a4bed2c4e482be046228ddc1` |
 | `.gitignore` | `text` | 609 | 68 | `e8bcab25f2bf6dcd69f95a4a3799bfc7f3f0fe840fa95ce879a6d65c62567f26` |
-| `AGENTS.md` | `text` | 763 | 22 | `e1a4e2d026f7402b861674bb5615f9a56f9f14b7d3f3c781851cffe304a71756` |
-| `CLAUDE.md` | `text` | 14282 | 206 | `9bc0059fbd3f785861229e05778a1e9b5bead10d039b11bf414135c015e81809` |
-| `GEMINI.md` | `text` | 957 | 19 | `06f4ee20523b516b296c427463c6ad891e9f242f3bc8693b18fdbee13011f0ac` |
+| `AGENTS.md` | `text` | 496 | 21 | `b5ddb1fd4175306209c9a5dd2ceb0b69333c71c744f20fa72f67064ccb119247` |
+| `CLAUDE.md` | `text` | 25224 | 418 | `643b6edf069642b8df8b3bfe4402b11fceea186480ba9737f23f121f2150b322` |
+| `DISCOVERY.md` | `text` | 3111 | 21 | `30c511c5d11779483a56c5116be2c0c0fb8326df773e4e553a25d5d8d15b8aac` |
+| `GEMINI.md` | `text` | 11908 | 231 | `1afdc5a54732d02bddd774ef5b1bf3ada371f00bc239b98b8c37aa2d554b8314` |
 | `LICENSE` | `text` | 1064 | 22 | `6d319436c6a6428d1cfa592e3386aef31cb02e04d67731a577b68395c5e963fc` |
 | `MANIFEST.yaml` | `text` | 73790 | 1931 | `eabc9892bf75038588d9e77eec64f4b4dd28cf28bbee7c376d4654b95def5d08` |
 | `Makefile` | `text` | 1316 | 61 | `88dbeff2a11f74f73e4ce9a01f2eaf78e64d30d0f4f65dfe9ae06db2bf2999e1` |
-| `README.md` | `text` | 41701 | 441 | `4e55cef95ef16aad3d659b91c65fc5f194cb74fcffe8932d99add216309362a2` |
+| `README.md` | `text` | 42055 | 449 | `ba1955a853ad09a3f923c533abd85c855799615865b96471f6572a1ab4bd66cd` |
 | `alembic.ini` | `text` | 570 | 38 | `10cbd807a4fd691b24ef067c98e10ca269c0455c11f3fdd16dcf9c2bf30bc4fc` |
 | `alembic/env.py` | `text` | 1258 | 48 | `ca979c9c3923b76f89d216b92636f6c759cffee075b8f7c0117f984b020356ae` |
 | `alembic/script.py.mako` | `text` | 546 | 27 | `45b179250bf89ed063fb4304fa9e0c23979e7126daf8937177e85b6cbcd10829` |
@@ -82,7 +86,11 @@
 | `docs/reviews/evaluation_to_growth_2026-02-25.md` | `text` | 14874 | 337 | `e9f0e047d1c0777491d8e5bcac25542b1794f5464e3aba62d408e50991ab9cb6` |
 | `docs/roadmap.md` | `text` | 20844 | 1003 | `a7f47ace061f4af8f04cd59f3424d53b7f0aaf83f4bdad97dc0feef472696f25` |
 | `docs/roadmap_mvp_next.md` | `text` | 5710 | 167 | `ecec78412332cf299807ef91e84d76a5f93eb8dfa1c94d0866c0545753516edc` |
-| `pyproject.toml` | `text` | 1012 | 52 | `ac49fcafb9ed7d3cdddf58be1a1351e30197972670161fd32d920186522a2e14` |
+| `ecosystem.yaml` | `text` | 536 | 19 | `ba1dc959b4cd5c61660899f46700eb91051d84bb9e2cc2be10c9442054c0ed35` |
+| `ecosystem/pillar-dna/content.yaml` | `text` | 810 | 39 | `846552206789f78c0291bafd3fc752226d788108eef138abf7ce0b0f962b8bce` |
+| `ecosystem/pillar-dna/delivery.yaml` | `text` | 928 | 41 | `dbb0b6248c4a99da07d6527074969effad35b9fd3237aaf18a6ea37a0530e5e0` |
+| `network-map.yaml` | `text` | 1916 | 90 | `e458bca6737a298b73ad5ab19e2fa23108f24fdf710159ddebd7a76c6cccc886` |
+| `pyproject.toml` | `text` | 1015 | 52 | `64baa66bc9f2e6f638c32b5e2f6c38053ff8d75b84c6f90a8ce2e1fc3b7117c4` |
 | `scripts/alexandria_babel_alignment.py` | `text` | 13948 | 359 | `5cb14497811b005aee06701d434afd3e00682c98e51900de4db11c33f5030313` |
 | `scripts/demo_sequence.py` | `text` | 10806 | 264 | `442ac9e5190e14fd3c6b0287fe16ad989a2f7f2d60dddeba578680dc00c90bb0` |
 | `scripts/export_atom_library.py` | `text` | 5444 | 140 | `0a7b00bc5a44752ac15b2e79628a1237177af611a61a0f06a13f9775fcb9ff68` |
@@ -93,7 +101,7 @@
 | `scripts/repo_certainty_audit.py` | `text` | 16897 | 445 | `b7ed92ac179e09a308847793a97b42258c545dd99b1022e9e440e532bd55e284` |
 | `scripts/run_api.sh` | `text` | 103 | 4 | `ef5c1e6448a8a103d3e4639927be0617cbd5d4a143cfbe23193b8c2980638e0c` |
 | `scripts/visualize_atoms.py` | `text` | 9889 | 250 | `e5faac7df16778083e5e3d7afb34b036acb7ea175ff12084b718fa787131d58d` |
-| `seed.yaml` | `text` | 1094 | 42 | `2937e7625e3495a0233aa3e29b91dd3d27a65c8ef3029b7254a4da1115d13f92` |
+| `seed.yaml` | `text` | 1551 | 50 | `3d7e13674166b3f8032fe02597afb25396a840127f0fb0c7896aa0200df228ca` |
 | `specs/01-ingestion-atomization/plan.md` | `text` | 18553 | 408 | `96e6049254a577da6aec54c9c675aeb259c18d9942a6517f14ac67f43d9ce75e` |
 | `specs/01-ingestion-atomization/spec.md` | `text` | 28811 | 431 | `874734a508493a604e4bd276e42935dd01772419795ef7f158fded2a73f98422` |
 | `specs/01-ingestion-atomization/tasks.md` | `text` | 18207 | 425 | `76ce71c753c92e047b49758d9b6266ce746df364c69e004ccd8d4722957bbcfd` |
@@ -193,7 +201,8 @@
 | `tests/test_plugins.py` | `text` | 1633 | 45 | `89783f06b2af0d02412b00de8c6feee6cea6603089b78621daf30f8628a19771` |
 | `tests/test_remix_helpers.py` | `text` | 3641 | 106 | `c8425c7cb60a0aeaeebfc080c602f9b5388ee66a03002c7f6b392a24cab48f91` |
 | `tests/test_wave2.py` | `text` | 5588 | 152 | `17c2ed71e00b559bcae1d9b4f2bab4c428480668f0996df906f29918d93e38d2` |
-| `uv.lock` | `text` | 332744 | 1541 | `ffee93fe4c0c746356a4f199c2e7705e2408d147245888289ec3b0f50928bc39` |
+| `uv.lock` | `text` | 332744 | 1541 | `1b1094b651712b936a78314fda34826cf548ce2c5e9efb8136acdbe3afd8dcc6` |
+| `value-repos.json` | `text` | 40 | 4 | `78a795874f3234a06ded5ab1ebf32984b446feb260f812ff17aa70e9ba010204` |
 
 ## Feature/Use-Case Ledger
 

--- a/value-repos.json
+++ b/value-repos.json
@@ -1,0 +1,3 @@
+[
+  "organvm/nexus--babel-alexandria"
+]


### PR DESCRIPTION
Autonomous **limen** dispatch of task `HEAL-cifix-organvm-nexus--babel-alexandria-125`.

PR organvm/nexus--babel-alexandria#125 has FAILING CI checks and merge-drain correctly refuses to merge it. Check out the PR branch, find the root cause of the red checks (lint / types / failing test / config), fix it, push to the SAME PR branch, and confirm every check goes green. Do not open a new PR — repair the existing one so merge-drain lands it. PR: https://github.com/organvm/nexus--babel-alexandria/pull/125 [auto-emitted 2026-07-04 by self-heal so merge-drain can land it]

Refs: https://github.com/organvm/nexus--babel-alexandria/pull/125

_Produced in an isolated worktree off origin — review before merge._